### PR TITLE
CIではPNPM_VERSIONを指定しない

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,6 @@ permissions:
   pull-requests: read
 env:
   GO_VERSION: 1.23.2
-  PNPM_VERSION: 9.15.4
   NODE_VERSION: 20.9.0
 jobs:
   filter:
@@ -113,7 +112,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: ${{ env.PNPM_VERSION}}
           package_json_file: "frontend/package.json"
       - uses: actions/setup-node@v4
         with:
@@ -131,7 +129,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: ${{ env.PNPM_VERSION}}
           package_json_file: "frontend/package.json"
       - uses: actions/setup-node@v4
         with:
@@ -149,8 +146,6 @@ jobs:
   #   steps:
   #     - uses: actions/checkout@v4
   #     - uses: pnpm/action-setup@v4
-  #       with:
-  #         version: ${{ env.PNPM_VERSION}}
   #     - uses: actions/setup-node@v4
   #       with:
   #         node-version: ${{ env.NODE_VERSION }}
@@ -166,7 +161,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: ${{ env.PNPM_VERSION}}
           package_json_file: "spec/package.json"
       - uses: actions/setup-node@v4
         with:
@@ -185,7 +179,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: ${{ env.PNPM_VERSION}}
           package_json_file: "example/package.json"
       - uses: actions/setup-node@v4
         with:
@@ -203,7 +196,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: ${{ env.PNPM_VERSION}}
           package_json_file: "example/package.json"
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/prd-deploy.yaml
+++ b/.github/workflows/prd-deploy.yaml
@@ -11,7 +11,6 @@ permissions:
   pages: write
   packages: write
 env:
-  PNPM_VERSION: 9.15.4
   NODE_VERSION: 20.9.0
 
 jobs:
@@ -90,7 +89,6 @@ jobs:
         uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: ${{ env.PNPM_VERSION}}
           package_json_file: "spec/package.json"
       - uses: actions/setup-node@v4
         with:

--- a/spec/package.json
+++ b/spec/package.json
@@ -2,6 +2,7 @@
   "name": "spec",
   "version": "0.1.0",
   "type": "module",
+  "packageManager": "pnpm@9.15.4",
   "scripts": {
     "compile": "tsp compile .",
     "dev": "tsp compile . --watch",


### PR DESCRIPTION
CIでPNPM_VERSIONを指定する必要はない：https://github.com/pnpm/action-setup/tree/v4/

> Optional when there is a [packageManager field in the package.json](https://nodejs.org/api/corepack.html).